### PR TITLE
[Android] revise layout of signin and register for small screen

### DIFF
--- a/RealmTasks Android/app/src/main/res/layout/activity_register.xml
+++ b/RealmTasks Android/app/src/main/res/layout/activity_register.xml
@@ -28,8 +28,8 @@
             android:orientation="vertical"
             android:paddingTop="48dp"
             android:paddingBottom="@dimen/activity_vertical_margin"
-            android:layout_marginLeft="@dimen/signin_horizontal_margin"
-            android:layout_marginRight="@dimen/signin_horizontal_margin">
+            android:paddingLeft="@dimen/signin_horizontal_margin"
+            android:paddingRight="@dimen/signin_horizontal_margin">
 
             <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"

--- a/RealmTasks Android/app/src/main/res/layout/activity_sign_in.xml
+++ b/RealmTasks Android/app/src/main/res/layout/activity_sign_in.xml
@@ -30,8 +30,8 @@
             android:orientation="vertical"
             android:paddingTop="48dp"
             android:paddingBottom="@dimen/activity_vertical_margin"
-            android:layout_marginLeft="@dimen/signin_horizontal_margin"
-            android:layout_marginRight="@dimen/signin_horizontal_margin">
+            android:paddingLeft="@dimen/signin_horizontal_margin"
+            android:paddingRight="@dimen/signin_horizontal_margin">
 
             <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"

--- a/RealmTasks Android/app/src/main/res/values-w400dp/dimens.xml
+++ b/RealmTasks Android/app/src/main/res/values-w400dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="signin_horizontal_margin">64dp</dimen>
+</resources>

--- a/RealmTasks Android/app/src/main/res/values/dimens.xml
+++ b/RealmTasks Android/app/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
 
-    <dimen name="signin_horizontal_margin">64dp</dimen>
+    <dimen name="signin_horizontal_margin">48dp</dimen>
     <dimen name="padding_bottom_pull_down">16dp</dimen>
     <dimen name="row_min_height">55dp</dimen>
     <dimen name="row_icon_margin">20dp</dimen>


### PR DESCRIPTION
For example, on Nexus 5 (1080x1920, 420dpi), current layout does not show sign-in Activity as expected.

Before: 
<img src="https://cloud.githubusercontent.com/assets/406660/24328620/e202440e-1228-11e7-9f20-d04dbb90ae23.png" width="300px">

After:
<img src="https://cloud.githubusercontent.com/assets/406660/24328630/2820da72-1229-11e7-9a24-ba0b8eb76df7.png" width="300px">
