### PR TITLE
Add the date metadata to tasks lists.

### DIFF
--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/ItemViewHolder.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/ItemViewHolder.java
@@ -146,7 +146,7 @@ public class ItemViewHolder extends RecyclerView.ViewHolder {
             if (isEditable() == true) {
                 text.setText(editText.getText().toString());
             }
-            text.setVisibility(View.VISIBLE);
+            showReadOnlyTaskText();
             editText.setVisibility(View.GONE);
         }
     }

--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/ItemViewHolder.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/ItemViewHolder.java
@@ -28,7 +28,6 @@ import android.text.style.CharacterStyle;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StrikethroughSpan;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.RotateAnimation;
 import android.view.inputmethod.InputMethodManager;
@@ -37,8 +36,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
-import org.w3c.dom.Text;
 
 import io.realm.realmtasks.R;
 

--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
@@ -17,10 +17,14 @@
 package io.realm.realmtasks.list;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
+import android.text.format.DateUtils;
 import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import java.util.Date;
 
 import io.realm.OrderedRealmCollection;
 import io.realm.Realm;
@@ -41,10 +45,27 @@ public class TaskAdapter extends CommonAdapter<Task> implements TouchHelperAdapt
         if (task.isValid()) {
             final TextView text = itemViewHolder.getText();
             text.setText(task.getText());
+
+            Date taskDate = task.getDate();
+            if(taskDate != null) {
+                CharSequence naturalDateString = naturalDateFrom(taskDate);
+                itemViewHolder.setMetadataText(naturalDateString);
+            } else {
+                itemViewHolder.setMetadataText(null);
+            }
             narrowRightMargin(text);
             narrowRightMargin(itemViewHolder.getEditText());
             itemViewHolder.setCompleted(task.isCompleted());
         }
+    }
+
+    private String naturalDateFrom(@NonNull Date taskDueDate) {
+        return DateUtils.getRelativeDateTimeString(
+                context,
+                taskDueDate.getTime(),
+                DateUtils.DAY_IN_MILLIS,
+                DateUtils.WEEK_IN_MILLIS, 0).toString()
+                .replace(",", " at");
     }
 
     private void narrowRightMargin(View view) {
@@ -85,7 +106,7 @@ public class TaskAdapter extends CommonAdapter<Task> implements TouchHelperAdapt
     public void onItemCompleted(final int position) {
         final Task task = getData().get(position);
         final Realm realm = Realm.getDefaultInstance();
-        final int count = (int) ((RealmList<Task>) getData()).where().equalTo(Task.FIELD_COMPLETED, false).count();
+        final int count = (int) getData().where().equalTo(Task.FIELD_COMPLETED, false).count();
         realm.executeTransaction(new Realm.Transaction() {
             @Override
             public void execute(Realm realm) {

--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
@@ -28,7 +28,6 @@ import java.util.Date;
 
 import io.realm.OrderedRealmCollection;
 import io.realm.Realm;
-import io.realm.RealmList;
 import io.realm.realmtasks.model.Task;
 
 public class TaskAdapter extends CommonAdapter<Task> implements TouchHelperAdapter {

--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
@@ -58,13 +58,12 @@ public class TaskAdapter extends CommonAdapter<Task> implements TouchHelperAdapt
         }
     }
 
-    private String naturalDateFrom(@NonNull Date taskDueDate) {
+    private CharSequence naturalDateFrom(@NonNull Date taskDueDate) {
         return DateUtils.getRelativeDateTimeString(
                 context,
                 taskDueDate.getTime(),
                 DateUtils.DAY_IN_MILLIS,
-                DateUtils.WEEK_IN_MILLIS, 0).toString()
-                .replace(",", " at");
+                DateUtils.WEEK_IN_MILLIS, 0);
     }
 
     private void narrowRightMargin(View view) {

--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/list/TaskAdapter.java
@@ -167,6 +167,8 @@ public class TaskAdapter extends CommonAdapter<Task> implements TouchHelperAdapt
             public void execute(Realm realm) {
                 Task task = getData().get(position);
                 task.setText(viewHolder.getText().getText().toString());
+                task.setDate(null); // remove date on text change, server will set
+                                    // new value if there is a value to be set.
             }
         });
         realm.close();

--- a/RealmTasks Android/app/src/main/java/io/realm/realmtasks/model/Task.java
+++ b/RealmTasks Android/app/src/main/java/io/realm/realmtasks/model/Task.java
@@ -16,6 +16,8 @@
 
 package io.realm.realmtasks.model;
 
+import java.util.Date;
+
 import io.realm.RealmObject;
 import io.realm.annotations.Required;
 
@@ -23,10 +25,12 @@ public class Task extends RealmObject implements Completable {
 
     public static final String FIELD_TEXT = "text";
     public static final String FIELD_COMPLETED = "completed";
+    public static final String FIELD_DATE = "date";
 
     @Required
     private String text;
     private boolean completed;
+    private Date date;
 
     public String getText() {
         return text;
@@ -42,6 +46,14 @@ public class Task extends RealmObject implements Completable {
 
     public void setCompleted(boolean completed) {
         this.completed = completed;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
     }
 
     @Override

--- a/RealmTasks Android/app/src/main/res/layout/item_row.xml
+++ b/RealmTasks Android/app/src/main/res/layout/item_row.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:background="@android:color/black"
     android:minHeight="@dimen/row_min_height">
 
@@ -16,16 +16,22 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
             android:layout_marginLeft="@dimen/row_icon_margin"
+            android:layout_marginStart="@dimen/row_icon_margin"
+            android:contentDescription="@string/done_indicator_content_description"
             android:src="@drawable/ic_done"/>
 
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:layout_marginRight="@dimen/row_icon_margin"
+            android:layout_marginEnd="@dimen/row_icon_margin"
+            android:contentDescription="@string/delete_icon_content_description"
             android:src="@drawable/ic_delete"/>
 
     </RelativeLayout>
@@ -45,9 +51,12 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="@dimen/row_text_margin_left"
+                android:layout_marginStart="@dimen/row_text_margin_left"
                 android:layout_marginRight="@dimen/row_text_margin_right"
+                android:layout_marginEnd="@dimen/row_text_margin_right"
                 android:paddingTop="@dimen/row_text_padding"
                 android:text="@string/row_text_placeholder"
                 android:textColor="@android:color/white"
@@ -61,8 +70,11 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="@dimen/row_text_margin_left"
+                android:layout_marginStart="@dimen/row_text_margin_left"
                 android:layout_marginRight="@dimen/row_text_margin_right"
+                android:layout_marginEnd="@dimen/row_text_margin_right"
                 android:textColor="@android:color/white"
+                android:inputType="text"
                 android:visibility="gone"/>
 
             <TextView
@@ -70,7 +82,8 @@
                 android:layout_width="@dimen/row_badge_width"
                 android:layout_height="match_parent"
                 android:layout_alignParentRight="true"
-                android:background="#26FFFFFF"
+                android:layout_alignParentEnd="true"
+                android:background="@color/badge_background_color"
                 android:gravity="center"
                 android:text="@string/badge_placeholder"
                 android:textColor="@android:color/white"
@@ -80,7 +93,7 @@
 
         </RelativeLayout>
 
-        <RelativeLayout
+        <FrameLayout
             android:id="@+id/row_metadata"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -90,10 +103,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingTop="@dimen/row_metadata_padding_top"
-                android:layout_alignParentLeft="true"
-                android:layout_centerVertical="true"
+                android:layout_marginStart="@dimen/row_text_margin_left"
                 android:layout_marginLeft="@dimen/row_text_margin_left"
                 android:layout_marginRight="@dimen/row_text_margin_right"
+                android:layout_marginEnd="@dimen/row_text_margin_right"
                 android:paddingBottom="@dimen/row_text_padding"
                 android:text="@string/row_text_placeholder"
                 android:textColor="@color/cell_default_metadata_color"
@@ -101,7 +114,7 @@
                 tools:text="Today at 5:00 PM"
                 />
 
-        </RelativeLayout>
+        </FrameLayout>
     </LinearLayout>
 
     <RelativeLayout
@@ -116,6 +129,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
+            android:layout_toStartOf="@+id/arrow"
+            android:layout_toLeftOf="@id/arrow"
             android:text="@string/switch_to_lists"
             android:textColor="@android:color/white"/>
 
@@ -125,7 +140,10 @@
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
             android:layout_marginRight="@dimen/row_arrow_margin"
+            android:layout_marginEnd="@dimen/row_arrow_margin"
             android:layout_toLeftOf="@id/switch_hint"
+            android:layout_toStartOf="@id/switch_hint"
+            android:contentDescription="@string/cell_arrow_content_description"
             android:src="@drawable/ic_arrow"/>
 
     </RelativeLayout>

--- a/RealmTasks Android/app/src/main/res/layout/item_row.xml
+++ b/RealmTasks Android/app/src/main/res/layout/item_row.xml
@@ -40,7 +40,10 @@
         android:id="@+id/row"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingTop="@dimen/row_text_padding"
+        android:paddingBottom="@dimen/row_text_padding"
+        >
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -57,7 +60,6 @@
                 android:layout_marginStart="@dimen/row_text_margin_left"
                 android:layout_marginRight="@dimen/row_text_margin_right"
                 android:layout_marginEnd="@dimen/row_text_margin_right"
-                android:paddingTop="@dimen/row_text_padding"
                 android:text="@string/row_text_placeholder"
                 android:textColor="@android:color/white"
                 android:textSize="@dimen/row_text_size"
@@ -74,7 +76,7 @@
                 android:layout_marginRight="@dimen/row_text_margin_right"
                 android:layout_marginEnd="@dimen/row_text_margin_right"
                 android:textColor="@android:color/white"
-                android:inputType="text"
+                android:inputType="textMultiLine"
                 android:visibility="gone"/>
 
             <TextView
@@ -107,7 +109,6 @@
                 android:layout_marginLeft="@dimen/row_text_margin_left"
                 android:layout_marginRight="@dimen/row_text_margin_right"
                 android:layout_marginEnd="@dimen/row_text_margin_right"
-                android:paddingBottom="@dimen/row_text_padding"
                 android:text="@string/row_text_placeholder"
                 android:textColor="@color/cell_default_metadata_color"
                 android:textSize="@dimen/row_metadata_text_size"
@@ -129,8 +130,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:layout_toStartOf="@+id/arrow"
-            android:layout_toLeftOf="@id/arrow"
             android:text="@string/switch_to_lists"
             android:textColor="@android:color/white"/>
 

--- a/RealmTasks Android/app/src/main/res/layout/item_row.xml
+++ b/RealmTasks Android/app/src/main/res/layout/item_row.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:background="@android:color/black"
     android:minHeight="@dimen/row_min_height">
 
@@ -30,48 +30,79 @@
 
     </RelativeLayout>
 
-    <RelativeLayout
+    <LinearLayout
         android:id="@+id/row"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:layout_marginLeft="@dimen/row_text_margin_left"
-            android:layout_marginRight="@dimen/row_text_margin_right"
-            android:paddingBottom="@dimen/row_text_padding"
-            android:paddingTop="@dimen/row_text_padding"
-            android:text="@string/row_text_placeholder"
-            android:textColor="@android:color/white"
-            android:textSize="@dimen/row_text_size"/>
-
-        <EditText
-            android:id="@+id/edit_text"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_marginLeft="@dimen/row_text_margin_left"
-            android:layout_marginRight="@dimen/row_text_margin_right"
-            android:textColor="@android:color/white"
-            android:visibility="gone"/>
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/badge"
-            android:layout_width="@dimen/row_badge_width"
-            android:layout_height="match_parent"
-            android:layout_alignParentRight="true"
-            android:background="#26FFFFFF"
-            android:gravity="center"
-            android:text="@string/badge_placeholder"
-            android:textColor="@android:color/white"
-            android:textSize="@dimen/row_text_size"
-            android:visibility="gone"/>
+            <TextView
+                android:id="@+id/text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_centerVertical="true"
+                android:layout_marginLeft="@dimen/row_text_margin_left"
+                android:layout_marginRight="@dimen/row_text_margin_right"
+                android:paddingTop="@dimen/row_text_padding"
+                android:text="@string/row_text_placeholder"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/row_text_size"
+                tools:text="Go shopping at 5pm"
+                />
 
-    </RelativeLayout>
+            <EditText
+                android:id="@+id/edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_marginLeft="@dimen/row_text_margin_left"
+                android:layout_marginRight="@dimen/row_text_margin_right"
+                android:textColor="@android:color/white"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/badge"
+                android:layout_width="@dimen/row_badge_width"
+                android:layout_height="match_parent"
+                android:layout_alignParentRight="true"
+                android:background="#26FFFFFF"
+                android:gravity="center"
+                android:text="@string/badge_placeholder"
+                android:textColor="@android:color/white"
+                android:textSize="@dimen/row_text_size"
+                android:visibility="gone"
+                />
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/row_metadata"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/task_metadata"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/row_metadata_padding_top"
+                android:layout_alignParentLeft="true"
+                android:layout_centerVertical="true"
+                android:layout_marginLeft="@dimen/row_text_margin_left"
+                android:layout_marginRight="@dimen/row_text_margin_right"
+                android:paddingBottom="@dimen/row_text_padding"
+                android:text="@string/row_text_placeholder"
+                android:textColor="@color/cell_default_metadata_color"
+                android:textSize="@dimen/row_metadata_text_size"
+                tools:text="Today at 5:00 PM"
+                />
+
+        </RelativeLayout>
+    </LinearLayout>
 
     <RelativeLayout
         android:id="@+id/hint_panel"

--- a/RealmTasks Android/app/src/main/res/values/colors.xml
+++ b/RealmTasks Android/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="completing">#FF078D00</color>
     <color name="cell_completed_color">#4CFFFFFF</color>
     <color name="cell_default_color">#FFFFFFFF</color>
+    <color name="cell_default_metadata_color">#FFF4F5F5</color>
     <color name="cell_unused_color">#FF000000</color>
     <color name="cell_completed_background_color">#FF262626</color>
 </resources>

--- a/RealmTasks Android/app/src/main/res/values/colors.xml
+++ b/RealmTasks Android/app/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="colorAccent">#FF4081</color>
     <color name="completing">#FF078D00</color>
     <color name="cell_completed_color">#4CFFFFFF</color>
+    <color name="badge_background_color">#26FFFFFF</color>
     <color name="cell_default_color">#FFFFFFFF</color>
     <color name="cell_default_metadata_color">#FFF4F5F5</color>
     <color name="cell_unused_color">#FF000000</color>

--- a/RealmTasks Android/app/src/main/res/values/dimens.xml
+++ b/RealmTasks Android/app/src/main/res/values/dimens.xml
@@ -12,6 +12,8 @@
     <dimen name="row_badge_width">60dp</dimen>
     <dimen name="row_arrow_margin">10dp</dimen>
     <dimen name="row_text_padding">16dp</dimen>
-    <dimen name="row_text_size">18dp</dimen>
+    <dimen name="row_text_size">18sp</dimen>
+    <dimen name="row_metadata_padding_top">6dp</dimen>
+    <dimen name="row_metadata_text_size">12sp</dimen>
 
 </resources>

--- a/RealmTasks Android/app/src/main/res/values/strings.xml
+++ b/RealmTasks Android/app/src/main/res/values/strings.xml
@@ -26,5 +26,8 @@
     <string name="badge_placeholder">3</string>
     <string name="switch_to_lists">Switch to Lists</string>
     <string name="row_text_placeholder">Text</string>
+    <string name="done_indicator_content_description">Done Indicator</string>
+    <string name="delete_icon_content_description">Delete Icon</string>
+    <string name="cell_arrow_content_description">Arrow</string>
 
 </resources>

--- a/RealmTasks Android/build.gradle
+++ b/RealmTasks Android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'io.realm:realm-gradle-plugin:2.3.0'
     }


### PR DESCRIPTION
This update is to display a date associated with a task which which may be populated by the realm tasks server.  When populated it should be displayed in natural formatting similar to the example screenshot here.  If it's not present (i.e. blank) the entire sub row should be hidden and take no space (as shown).

![image](https://cloud.githubusercontent.com/assets/219132/25409054/66a559ea-29de-11e7-9501-51f68c4a5324.png)
